### PR TITLE
Remove the dependency on usage client from the extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.wso2.apim.monetization</groupId>
     <artifactId>org.wso2.apim.monetization.impl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
@@ -17,11 +17,6 @@
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.api</artifactId>
-            <version>${carbon.apimgt.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.apimgt</groupId>
-            <artifactId>org.wso2.carbon.apimgt.usage.client</artifactId>
             <version>${carbon.apimgt.version}</version>
         </dependency>
         <dependency>
@@ -47,7 +42,7 @@
     </repositories>
 
     <properties>
-        <carbon.apimgt.version>6.5.349</carbon.apimgt.version>
+        <carbon.apimgt.version>6.6.145</carbon.apimgt.version>
         <commons.lang.version>2.6</commons.lang.version>
         <stripe.version>9.8.0</stripe.version>
     </properties>

--- a/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationImpl.java
+++ b/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationImpl.java
@@ -54,9 +54,6 @@ import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
-import org.wso2.carbon.apimgt.usage.client.APIUsageStatisticsClientConstants;
-import org.wso2.carbon.apimgt.usage.client.exception.APIMgtUsageQueryServiceClientException;
-import org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRestClientImpl;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.Resource;
@@ -625,11 +622,10 @@ public class StripeMonetizationImpl implements Monetization {
         String currentDate = df.format(dateobj);
         currentTimestamp = getTimestamp(currentDate);
         try {
-            APIUsageStatisticsRestClientImpl apiUsageStatisticsRestClient = new APIUsageStatisticsRestClientImpl();
             //get the data from SP rest queries as a json object
-            jsonObj = apiUsageStatisticsRestClient.getUsageCountForMonetization(lastPublishInfo.getLastPublishTime(),
+            jsonObj = APIUtil.getUsageCountForMonetization(lastPublishInfo.getLastPublishTime(),
                     currentTimestamp);
-        } catch (APIMgtUsageQueryServiceClientException e) {
+        } catch (APIManagementException e) {
             String errorMessage = "Failed to get the usage count for monetization.";
             //throw MonetizationException as it will be logged and handled by the caller
             throw new MonetizationException(errorMessage, e);
@@ -638,7 +634,7 @@ public class StripeMonetizationImpl implements Monetization {
         SubscriptionItem subscriptionItem = null;
         try {
             if (jsonObj != null) {
-                JSONArray jArray = (JSONArray) jsonObj.get(APIUsageStatisticsClientConstants.RECORDS_DELIMITER);
+                JSONArray jArray = (JSONArray) jsonObj.get(APIConstants.Analytics.RECORDS_DELIMITER);
                 for (Object record : jArray) {
                     JSONArray recordArray = (JSONArray) record;
                     // should return the 6 paramters derived below


### PR DESCRIPTION
## Purpose
Due to removing the usage module(carbon-apimgt) in latest releases, the dependency on the above module in the extension is removed and neccessary code are moved to Impl. 

