### PR TITLE
Add Monetization support via Elasticsearch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>commons-lang</artifactId>
             <version>${commons.lang.version}</version>
         </dependency>
+        <dependency>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-java</artifactId>
+            <version>${elastic.client.version}</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>
@@ -47,9 +52,10 @@
     </repositories>
 
     <properties>
-        <carbon.apimgt.version>9.20.52</carbon.apimgt.version>
+        <carbon.apimgt.version>9.22.16</carbon.apimgt.version>
         <commons.lang.version>2.6</commons.lang.version>
         <stripe.version>9.8.0</stripe.version>
+        <elastic.client.version>8.3.1</elastic.client.version>
     </properties>
 
     <build>

--- a/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationConstants.java
+++ b/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationConstants.java
@@ -155,19 +155,11 @@ public class StripeMonetizationConstants {
     public static final String GET_USAGE_BY_APPLICATION = "getSuccessAPIsUsageByApplications";
     public static final String GET_USAGE_BY_APPLICATION_WITH_ON_PREM_KEY = "getSuccessAPIsUsageByApplicationsWithOnPremKey";
     public static final String AT = "@";
-
     public static final String DEFAULT_ELK_ANALYTICS_INDEX = "apim_event_response";
-
     public static final String REQUEST_TIMESTAMP_COLUMN = "requestTimestamp";
-
     public static final String ELK_API_ID_COL = "apiId.keyword";
-
     public static final String ELK_TENANT_DOMAIN = "apiCreatorTenantDomain.keyword";
-
     public static final String APPLICATION_ID_COLUMN = "applicationId";
-
     public static final String ELK_APPLICATION_ID_COLUMN = "applicationId.keyword";
-
-
 
 }

--- a/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationConstants.java
+++ b/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationConstants.java
@@ -155,4 +155,19 @@ public class StripeMonetizationConstants {
     public static final String GET_USAGE_BY_APPLICATION = "getSuccessAPIsUsageByApplications";
     public static final String GET_USAGE_BY_APPLICATION_WITH_ON_PREM_KEY = "getSuccessAPIsUsageByApplicationsWithOnPremKey";
     public static final String AT = "@";
+
+    public static final String DEFAULT_ELK_ANALYTICS_INDEX = "apim_event_response";
+
+    public static final String REQUEST_TIMESTAMP_COLUMN = "requestTimestamp";
+
+    public static final String ELK_API_ID_COL = "apiId.keyword";
+
+    public static final String ELK_TENANT_DOMAIN = "apiCreatorTenantDomain.keyword";
+
+    public static final String APPLICATION_ID_COLUMN = "applicationId";
+
+    public static final String ELK_APPLICATION_ID_COLUMN = "applicationId.keyword";
+
+
+
 }

--- a/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationImpl.java
+++ b/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationImpl.java
@@ -1101,7 +1101,7 @@ public class StripeMonetizationImpl implements Monetization {
 
                 return elasticsearchClient.search(searchRequest, Object.class);
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new MonetizationException("Error occurred while executing data retrieval from Elasticsearch", e);
             }
         } else {
             try (RestClient restClient = RestClient.builder(new HttpHost(hostname, port))


### PR DESCRIPTION
## Purpose
> This PR will add Monetization support via Elasticsearch. Following configuration changes are needed In order to enable the  stripe monetization with Elasticsearch

Add following configuration changes should be applied to deployment.toml file

1. Enable ELK Based Analytics

```
[apim.analytics]
enable = true
type = "ELK"
```
2. Provide Elasticsearch host, port and authentication details

```
[apim.monetization]
monetization_impl = "org.wso2.apim.monetization.impl.StripeMonetizationImpl"
analytics_host = <hostname-of-elk-node>
analytics_port = <port-of-elk-node>
analytics_username = <elastic-username>
analytics_password = <elastic-password>
``` 

In order to use ELK  based Monatization, following 3rd party jars has to be downloaded and copy to /repository/components/lib directory.

- [elasticsearch-java-8.x.x.jar ](https://repo1.maven.org/maven2/co/elastic/clients/elasticsearch-java/8.3.1/elasticsearch-java-8.3.1.jar)
- [elasticsearch-rest-client-8.x.x.jar](https://repo1.maven.org/maven2/org/elasticsearch/client/elasticsearch-rest-client/8.3.1/elasticsearch-rest-client-8.3.1.jar)
- [httpasyncclient-4.x.x.jar](https://repo1.maven.org/maven2/org/apache/httpcomponents/httpasyncclient/4.1.5/httpasyncclient-4.1.5.jar)
- [jakarta.json-api-2.x.x.jar](https://repo1.maven.org/maven2/jakarta/json/jakarta.json-api/2.1.1/jakarta.json-api-2.1.1.jar)
- [parsson-1.x.x.jar](https://repo1.maven.org/maven2/org/eclipse/parsson/parsson/1.1.1/parsson-1.1.1.jar)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes