### PR TITLE
Pack some external dependencies with the plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <groupId>org.wso2.apim.monetization</groupId>
     <artifactId>org.wso2.apim.monetization.impl</artifactId>
     <version>1.3.3</version>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -39,6 +40,21 @@
             <artifactId>elasticsearch-java</artifactId>
             <version>${elastic.client.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+            <version>${elastic.rest.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+            <version>${http.async.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <version>${parsson.version}</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>
@@ -56,6 +72,13 @@
         <commons.lang.version>2.6</commons.lang.version>
         <stripe.version>9.8.0</stripe.version>
         <elastic.client.version>8.3.1</elastic.client.version>
+        <elastic.rest.client.version>8.3.1</elastic.rest.client.version>
+        <http.async.client.version>4.1.5</http.async.client.version>
+        <jakarta.json.version>2.1.1</jakarta.json.version>
+        <parsson.version>1.1.1</parsson.version>
+        <maven.bundle.version>3.0.1</maven.bundle.version>
+        <maven.compiler.version>3.5.1</maven.compiler.version>
+        <maven.scr.version>1.0.10</maven.scr.version>
     </properties>
 
     <build>
@@ -63,29 +86,33 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>1.4.0</version>
+                <version>${maven.bundle.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
-                            org.wso2.sample.apimgt.internal,
+                            co.elastic.clients.*,
+                            org.elasticsearch.client.*,
+                            org.apache.http.imple.nio.*,
+                            org.apache.http.nio.*,
+                            org.eclipse.parsson.*
                         </Private-Package>
                         <Export-Package>
-                            !org.wso2.sample.apimgt.internal,
-                            org.wso2.sample.apimgt.*,
+                            org.wso2.apim.monetization.impl.*
                         </Export-Package>
                         <Import-Package>
                             *;resolution:=optional
                         </Import-Package>
+                        <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-scr-plugin</artifactId>
-                <version>1.0.10</version>
+                <version>${maven.scr.version}</version>
                 <executions>
                     <execution>
                         <id>generate-scr-scrdescriptor</id>
@@ -98,6 +125,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.version}</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.wso2.apim.monetization</groupId>
     <artifactId>org.wso2.apim.monetization.impl</artifactId>
-    <version>1.3.3</version>
+    <version>1.4.0</version>
     <packaging>bundle</packaging>
 
     <dependencies>


### PR DESCRIPTION
## Purpose
This PR packs following dependencies required by ELK-based analytics monetization feature to the stripe plugin without getting them externally.

[elasticsearch-java-8.x.x.jar](https://repo1.maven.org/maven2/co/elastic/clients/elasticsearch-java/8.3.1/elasticsearch-java-8.3.1.jar)
[elasticsearch-rest-client-8.x.x.jar](https://repo1.maven.org/maven2/org/elasticsearch/client/elasticsearch-rest-client/8.3.1/elasticsearch-rest-client-8.3.1.jar)
[httpasyncclient-4.x.x.jar](https://repo1.maven.org/maven2/org/apache/httpcomponents/httpasyncclient/4.1.5/httpasyncclient-4.1.5.jar)
[Parsson-1.x.x.jar](https://repo1.maven.org/maven2/org/eclipse/parsson/parsson/1.1.1/parsson-1.1.1.jar)

This is to reduce complexity for customers.