### PR TITLE
Refactor `org.apache.http` related packages to private packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,8 @@
                         <Private-Package>
                             co.elastic.clients.*,
                             org.elasticsearch.client.*,
+                            org.apache.http.impl.nio.*,
+                            org.apache.http.nio.*,
                         </Private-Package>
                         <Export-Package>
                             org.wso2.apim.monetization.impl.*,
@@ -113,13 +115,10 @@
                         <Import-Package>
                             !com.google.gson.internal,
                             io.opentelemetry.api.common.*,
-                            org.apache.http.impl.nio.*,
-                            org.apache.http.nio.*,
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                         <Embed-Dependency>
                             opentelemetry-api;scope=compile|runtime;inline=false,
-                            httpasyncclient;scope=compile|runtime;inline=false,
                         </Embed-Dependency>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/3206

## Approach
The current implementation imports the `org.apache.http.impl.nio.*` and `org.apache.http.nio.*` packages from the OSGi runtime:
```xml
<Import-Package>
    !com.google.gson.internal,
    io.opentelemetry.api.common.*,
    org.apache.http.impl.nio.*,
    org.apache.http.nio.*,
</Import-Package>
```
Additionally, it bundles the `httpasyncclient` as an embedded dependency. 

This approach results in the following error:
```bash
java.lang.NoClassDefFoundError: org/apache/http/nio/client/HttpAsyncClient
```
The error occurs because the `HttpAsyncClient` class is not exported to the OSGi runtime, leading to missing class definitions at runtime.

This PR refactors the dependency management approach by moving the `org.apache.http.impl.nio.*` and `org.apache.http.nio.*` packages to private packages. This change ensures that these packages are no longer imported from the OSGi runtime but are instead encapsulated within the bundle.
As a result, bundling `httpasyncclient` as an embedded dependency is also removed, since it is no longer required.