### PR TITLE
Add proxy support for Stripe SDK

### DIFF
--- a/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationConstants.java
+++ b/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationConstants.java
@@ -155,4 +155,5 @@ public class StripeMonetizationConstants {
     public static final String GET_USAGE_BY_APPLICATION = "getSuccessAPIsUsageByApplications";
     public static final String GET_USAGE_BY_APPLICATION_WITH_ON_PREM_KEY = "getSuccessAPIsUsageByApplicationsWithOnPremKey";
     public static final String AT = "@";
+    public static final String MONETIZATION_PROXY_ENABLE_CONFIG = "Monetization.ProxyEnabled";
 }

--- a/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationImpl.java
+++ b/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationImpl.java
@@ -43,6 +43,7 @@ import org.wso2.apim.monetization.impl.model.GraphqlQueryModel;
 import org.wso2.apim.monetization.impl.model.MonetizedSubscription;
 import org.wso2.apim.monetization.impl.model.QueyAPIAccessTokenInterceptor;
 import org.wso2.apim.monetization.impl.model.graphQLResponseClient;
+import org.wso2.apim.monetization.impl.util.MonetizationUtil;
 import org.wso2.carbon.apimgt.api.APIAdmin;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
@@ -114,6 +115,7 @@ public class StripeMonetizationImpl implements Monetization {
      */
     public boolean createBillingPlan(SubscriptionPolicy subscriptionPolicy) throws MonetizationException {
 
+        MonetizationUtil.setProxy();
         try {
             //read tenant conf and get platform account key
             Stripe.apiKey = getStripePlatformAccountKey(subscriptionPolicy.getTenantDomain());
@@ -200,6 +202,7 @@ public class StripeMonetizationImpl implements Monetization {
      */
     public boolean updateBillingPlan(SubscriptionPolicy subscriptionPolicy) throws MonetizationException {
 
+        MonetizationUtil.setProxy();
         Map<String, String> planData = null;
         try {
             planData = stripeMonetizationDAO.getPlanData(subscriptionPolicy);
@@ -366,6 +369,7 @@ public class StripeMonetizationImpl implements Monetization {
      */
     public boolean deleteBillingPlan(SubscriptionPolicy subscriptionPolicy) throws MonetizationException {
 
+        MonetizationUtil.setProxy();
         //get old plan (if any) in the billing engine and delete
         Map<String, String> planData = null;
         try {
@@ -422,6 +426,7 @@ public class StripeMonetizationImpl implements Monetization {
     public boolean enableMonetization(String tenantDomain, API api, Map<String, String> monetizationProperties)
             throws MonetizationException {
 
+        MonetizationUtil.setProxy();
         String platformAccountKey = null;
         try {
             //read tenant conf and get platform account key
@@ -523,6 +528,7 @@ public class StripeMonetizationImpl implements Monetization {
      */
     public boolean disableMonetization(String tenantDomain, API api, Map<String, String> monetizationProperties) throws MonetizationException {
 
+        MonetizationUtil.setProxy();
         String platformAccountKey = null;
         try {
             //read tenant conf and get platform account key
@@ -657,7 +663,7 @@ public class StripeMonetizationImpl implements Monetization {
         int counter = 0;
         APIAdmin apiAdmin = new APIAdminImpl();
         SubscriptionItem subscriptionItem = null;
-
+        MonetizationUtil.setProxy();
         Date dateobj = new Date();
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat(StripeMonetizationConstants.TIME_FORMAT);
         simpleDateFormat.setTimeZone(TimeZone.getTimeZone(StripeMonetizationConstants.TIME_ZONE));
@@ -854,8 +860,7 @@ public class StripeMonetizationImpl implements Monetization {
 
         if (config == null) {
             // Retrieve the access token from api manager configurations.
-            config = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService().
-                    getAPIManagerConfiguration();
+            config = MonetizationUtil.getConfig();
         }
 
         String queryApiEndpoint = config.getMonetizationConfigurationDto().getInsightAPIEndpoint();

--- a/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationImpl.java
+++ b/src/main/java/org.wso2.apim.monetization/impl/StripeMonetizationImpl.java
@@ -63,7 +63,6 @@ import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.internal.MonetizationDataHolder;
-import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
 import org.wso2.carbon.apimgt.impl.utils.APINameComparator;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -992,7 +991,7 @@ public class StripeMonetizationImpl implements Monetization {
         String apiName = null;
         try {
             SubscribedAPI subscribedAPI = ApiMgtDAO.getInstance().getSubscriptionByUUID(subscriptionUUID);
-            APIIdentifier apiIdentifier = subscribedAPI.getApiId();
+            APIIdentifier apiIdentifier = subscribedAPI.getAPIIdentifier();
             APIProductIdentifier apiProductIdentifier;
             API api;
             APIProduct apiProduct;

--- a/src/main/java/org.wso2.apim.monetization/impl/util/MonetizationUtil.java
+++ b/src/main/java/org.wso2.apim.monetization/impl/util/MonetizationUtil.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.apim.monetization.impl.util;
+
+import com.stripe.Stripe;
+import org.wso2.apim.monetization.impl.StripeMonetizationConstants;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+
+public final class MonetizationUtil {
+
+    private static APIManagerConfiguration config;
+
+    public static void setProxy() {
+
+        if (Stripe.getConnectionProxy() == null) {
+            if (config == null) {
+                config = getConfig();
+            }
+            String proxyEnabled = config.getFirstProperty(APIConstants.PROXY_ENABLE);
+            //proxy enabled under monetization configs
+            String proxyEnabledForMonetization = config.getFirstProperty(
+                    StripeMonetizationConstants.MONETIZATION_PROXY_ENABLE_CONFIG);
+
+            if (Boolean.parseBoolean(proxyEnabled) && Boolean.parseBoolean(proxyEnabledForMonetization)) {
+                String proxyHost = config.getFirstProperty(APIConstants.PROXY_HOST);
+                String proxyPort = config.getFirstProperty(APIConstants.PROXY_PORT);
+                String proxyUsername = config.getFirstProperty(APIConstants.PROXY_USERNAME);
+                String proxyPassword = config.getFirstProperty(APIConstants.PROXY_PASSWORD);
+
+                InetSocketAddress inetSocketAddress = new InetSocketAddress(proxyHost,
+                        Integer.parseInt(proxyPort));
+                Proxy proxy = new Proxy(Proxy.Type.HTTP, inetSocketAddress);
+                Stripe.setConnectionProxy(proxy);
+                //set proxy auth
+                if (proxyUsername != null && proxyPassword != null) {
+                    PasswordAuthentication auth = new PasswordAuthentication(proxyUsername,
+                            proxyPassword.toCharArray());
+                    Stripe.setProxyCredential(auth);
+                }
+            }
+        }
+    }
+
+    public static APIManagerConfiguration getConfig() {
+        APIManagerConfiguration configuration = ServiceReferenceHolder.getInstance().
+                getAPIManagerConfigurationService().getAPIManagerConfiguration();
+        return configuration;
+    }
+
+}

--- a/src/main/java/org.wso2.apim.monetization/impl/workflow/StripeSubscriptionCreationWorkflowExecutor.java
+++ b/src/main/java/org.wso2.apim.monetization/impl/workflow/StripeSubscriptionCreationWorkflowExecutor.java
@@ -36,6 +36,7 @@ import org.wso2.apim.monetization.impl.StripeMonetizationDAO;
 import org.wso2.apim.monetization.impl.StripeMonetizationException;
 import org.wso2.apim.monetization.impl.model.MonetizationPlatformCustomer;
 import org.wso2.apim.monetization.impl.model.MonetizationSharedCustomer;
+import org.wso2.apim.monetization.impl.util.MonetizationUtil;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
 import org.wso2.carbon.apimgt.api.model.API;
@@ -123,6 +124,7 @@ public class StripeSubscriptionCreationWorkflowExecutor extends WorkflowExecutor
     @Override
     public WorkflowResponse monetizeSubscription(WorkflowDTO workflowDTO, API api) throws WorkflowException {
 
+        MonetizationUtil.setProxy();
         boolean isMonetizationEnabled = false;
         SubscriptionWorkflowDTO subWorkFlowDTO = null;
         String stripePlatformAccountKey = null;
@@ -227,6 +229,7 @@ public class StripeSubscriptionCreationWorkflowExecutor extends WorkflowExecutor
         MonetizationSharedCustomer monetizationSharedCustomer;
         ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
         subWorkFlowDTO = (SubscriptionWorkflowDTO) workflowDTO;
+        MonetizationUtil.setProxy();
         //read the platform account key of Stripe
         Stripe.apiKey = getPlatformAccountKey(subWorkFlowDTO.getTenantId());
         String connectedAccountKey = StringUtils.EMPTY;
@@ -335,6 +338,7 @@ public class StripeSubscriptionCreationWorkflowExecutor extends WorkflowExecutor
         Customer stripeCustomer;
         MonetizationSharedCustomer monetizationSharedCustomer = new MonetizationSharedCustomer();
         Token token;
+        MonetizationUtil.setProxy();
         try {
             Map<String, Object> params = new HashMap<String, Object>();
             params.put(StripeMonetizationConstants.CUSTOMER, platformCustomer.getCustomerId());
@@ -405,6 +409,7 @@ public class StripeSubscriptionCreationWorkflowExecutor extends WorkflowExecutor
         APIIdentifier identifier = new APIIdentifier(subWorkFlowDTO.getApiProvider(), subWorkFlowDTO.getApiName(),
                 subWorkFlowDTO.getApiVersion());
         Subscription subscription = null;
+        MonetizationUtil.setProxy();
         try {
             Map<String, Object> item = new HashMap<String, Object>();
             item.put(StripeMonetizationConstants.PLAN, planId);
@@ -459,6 +464,7 @@ public class StripeSubscriptionCreationWorkflowExecutor extends WorkflowExecutor
 
         MonetizationPlatformCustomer monetizationPlatformCustomer = new MonetizationPlatformCustomer();
         Customer customer = null;
+        MonetizationUtil.setProxy();
         try {
             Map<String, Object> customerParams = new HashMap<String, Object>();
             //Customer object in billing engine will be created without the email id

--- a/src/main/java/org.wso2.apim.monetization/impl/workflow/StripeSubscriptionDeletionWorkflowExecutor.java
+++ b/src/main/java/org.wso2.apim.monetization/impl/workflow/StripeSubscriptionDeletionWorkflowExecutor.java
@@ -31,6 +31,7 @@ import org.wso2.apim.monetization.impl.StripeMonetizationConstants;
 import org.wso2.apim.monetization.impl.StripeMonetizationDAO;
 import org.wso2.apim.monetization.impl.StripeMonetizationException;
 import org.wso2.apim.monetization.impl.model.MonetizedSubscription;
+import org.wso2.apim.monetization.impl.util.MonetizationUtil;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
 import org.wso2.carbon.apimgt.api.model.API;
@@ -123,6 +124,7 @@ public class StripeSubscriptionDeletionWorkflowExecutor extends WorkflowExecutor
         configMap.put(APIConstants.ALLOW_MULTIPLE_STATUS,
                 Boolean.toString(APIUtil.isAllowDisplayAPIsWithMultipleStatus()));
         apiPersistenceInstance = PersistenceManager.getPersistenceInstance(configMap, properties);
+        MonetizationUtil.setProxy();
         //read the platform key of Stripe
         Stripe.apiKey = getPlatformAccountKey(subWorkflowDTO.getTenantId());
         String connectedAccountKey = StringUtils.EMPTY;
@@ -202,6 +204,7 @@ public class StripeSubscriptionDeletionWorkflowExecutor extends WorkflowExecutor
         MonetizedSubscription monetizedSubscription;
         StripeMonetizationDAO stripeMonetizationDAO = new StripeMonetizationDAO();
         subWorkflowDTO = (SubscriptionWorkflowDTO) workflowDTO;
+        MonetizationUtil.setProxy();
         //read the platform key of Stripe
         Stripe.apiKey = getPlatformAccountKey(subWorkflowDTO.getTenantId());
         String connectedAccountKey = StringUtils.EMPTY;


### PR DESCRIPTION
Purpose

Add the proxy support to stripe sdk to be able to access stripe endpoints through proxy. The configurations for the proxy are derived from same api manager configurations.

But in addition, a new config is introduced under monetization config to enable/disable proxy only for monetization.

[apim.monetization]
proxy_enabled = true

The below system property should be set , if the proxy needs to support basic authentication due to a sdk level limitation.
-Djdk.http.auth.tunneling.disabledSchemes=""