### PR TITLE
Enhance monetization implementation with SSL support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,12 @@
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.impl</artifactId>
             <version>${carbon.apimgt.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wso2.am.analytics.publisher</groupId>
+                    <artifactId>org.wso2.am.analytics.publisher.client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
@@ -50,6 +56,12 @@
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
             <version>${elastic.rest.client.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpasyncclient</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -70,7 +82,8 @@
     </dependencies>
 
     <properties>
-        <carbon.apimgt.version>9.29.119</carbon.apimgt.version>
+<!--        TODO: UPDATE VERSION-->
+        <carbon.apimgt.version>9.32.119-SNAPSHOT</carbon.apimgt.version>
         <commons.lang.version>2.6</commons.lang.version>
         <stripe.version>9.8.0</stripe.version>
         <elastic.client.version>8.13.1</elastic.client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,7 @@
     </dependencies>
 
     <properties>
-<!--        TODO: UPDATE VERSION-->
-        <carbon.apimgt.version>9.32.119-SNAPSHOT</carbon.apimgt.version>
+        <carbon.apimgt.version>9.32.130</carbon.apimgt.version>
         <commons.lang.version>2.6</commons.lang.version>
         <stripe.version>9.8.0</stripe.version>
         <elastic.client.version>8.13.1</elastic.client.version>

--- a/src/main/java/org/wso2/apim/monetization/impl/StripeMonetizationConstants.java
+++ b/src/main/java/org/wso2/apim/monetization/impl/StripeMonetizationConstants.java
@@ -162,6 +162,8 @@ public class StripeMonetizationConstants {
     public static final String ELK_TENANT_DOMAIN = "apiCreatorTenantDomain.keyword";
     public static final String APPLICATION_ID_COLUMN = "applicationId";
     public static final String ELK_APPLICATION_ID_COLUMN = "applicationId.keyword";
+    public static final String HTTP_PROTOCOL = "http";
+    public static final String HTTPS_PROTOCOL = "https";
 
     public static final String MONETIZATION_PROXY_ENABLE_CONFIG = "Monetization.ProxyEnabled";
 }

--- a/src/main/java/org/wso2/apim/monetization/impl/StripeMonetizationImpl.java
+++ b/src/main/java/org/wso2/apim/monetization/impl/StripeMonetizationImpl.java
@@ -724,7 +724,8 @@ public class StripeMonetizationImpl implements Monetization {
         String formattedFromDate = fromDate.concat(StripeMonetizationConstants.TIMEZONE_FORMAT);
 
         if (config.getFirstProperty("Analytics.Type") != null
-                && !config.getFirstProperty("Analytics.Type").equals("")) {
+                && !config.getFirstProperty("Analytics.Type").isEmpty()
+                && !config.getFirstProperty("Analytics.Type").equals("choreo")) {
             SearchResponse<Object> searchResponse = getUsageDataFromElasticsearch(fromDate, toDate);
 
             if (log.isDebugEnabled()) {

--- a/src/main/java/org/wso2/apim/monetization/impl/StripeMonetizationImpl.java
+++ b/src/main/java/org/wso2/apim/monetization/impl/StripeMonetizationImpl.java
@@ -53,7 +53,9 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.ssl.SSLContexts;
 import org.elasticsearch.client.RestClient;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -103,6 +105,7 @@ import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
@@ -128,6 +131,8 @@ import static org.wso2.apim.monetization.impl.StripeMonetizationConstants.ELK_TE
 import static org.wso2.apim.monetization.impl.StripeMonetizationConstants.PRODUCTS;
 import static org.wso2.apim.monetization.impl.StripeMonetizationConstants.REQUEST_TIMESTAMP_COLUMN;
 import static org.wso2.apim.monetization.impl.StripeMonetizationConstants.TENANT_DOMAIN_COL;
+import static org.wso2.apim.monetization.impl.StripeMonetizationConstants.HTTP_PROTOCOL;
+import static org.wso2.apim.monetization.impl.StripeMonetizationConstants.HTTPS_PROTOCOL;
 
 /**
  * This class is used to implement stripe based monetization
@@ -1061,12 +1066,30 @@ public class StripeMonetizationImpl implements Monetization {
             analyticsIndex = DEFAULT_ELK_ANALYTICS_INDEX;
         }
         int port = config.getMonetizationConfigurationDto().getAnalyticsPort();
+        String protocol = config.getMonetizationConfigurationDto().getAnalyticsProtocol();
+        if (protocol == null) {
+            protocol = HTTP_PROTOCOL;
+        }
+
         List<JSONArray> tenantDomainsAndAPIs = getMonetizedAPIIdsAndTenantDomains();
         JSONArray tenants = tenantDomainsAndAPIs.get(0);
         JSONArray monetizedAPIs = tenantDomainsAndAPIs.get(1);
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username,
                 new String(password, StandardCharsets.UTF_8)));
+
+        final SSLContext sslContext;
+        if (HTTPS_PROTOCOL.equalsIgnoreCase(protocol)) {
+            try {
+                sslContext = SSLContexts.custom()
+                        .loadTrustMaterial(ServiceReferenceHolder.getInstance().getTrustStore(), null)
+                        .build();
+            } catch (Exception e) {
+                throw new MonetizationException("Failed to initialize SSL context for Elasticsearch connection", e);
+            }
+        } else {
+            sslContext = null;
+        }
 
         if (tenantDomainsAndAPIs.size() == 2) {
             List<FieldValue> tenantList = new ArrayList<>();
@@ -1077,9 +1100,15 @@ public class StripeMonetizationImpl implements Monetization {
             for (Object api : monetizedAPIs) {
                 monetizedAPIsList.add(new FieldValue.Builder().stringValue((String) api).build());
             }
-            try (RestClient restClient = RestClient.builder(new HttpHost(hostname, port))
-                    .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder
-                            .setDefaultCredentialsProvider(credentialsProvider)).build()) {
+            try (RestClient restClient = RestClient.builder(new HttpHost(hostname, port, protocol))
+                    .setHttpClientConfigCallback(httpClientBuilder -> {
+                        if (sslContext != null) {
+                            httpClientBuilder.setSSLContext(sslContext)
+                                    .setSSLHostnameVerifier(new DefaultHostnameVerifier());
+                        }
+                        return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                    }).build()) {
+
                 ElasticsearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
                 ElasticsearchClient elasticsearchClient = new ElasticsearchClient(transport);
 
@@ -1110,9 +1139,15 @@ public class StripeMonetizationImpl implements Monetization {
                 throw new MonetizationException("Error occurred while executing data retrieval from Elasticsearch", e);
             }
         } else {
-            try (RestClient restClient = RestClient.builder(new HttpHost(hostname, port))
-                    .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder
-                            .setDefaultCredentialsProvider(credentialsProvider)).build()) {
+            try (RestClient restClient = RestClient.builder(new HttpHost(hostname, port, protocol))
+                    .setHttpClientConfigCallback(httpClientBuilder -> {
+                        if (sslContext != null) {
+                            httpClientBuilder.setSSLContext(sslContext)
+                                    .setSSLHostnameVerifier(new DefaultHostnameVerifier());
+                        }
+                        return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                    }).build()) {
+
                 ElasticsearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
                 ElasticsearchClient elasticsearchClient = new ElasticsearchClient(transport);
                 Query query = RangeQuery.of(r -> r.field(REQUEST_TIMESTAMP_COLUMN)
@@ -1658,7 +1693,7 @@ public class StripeMonetizationImpl implements Monetization {
         UserContext userCtx = new UserContext(username, org, properties, roles);
         try {
             PublisherAPISearchResult searchAPIs = apiPersistenceInstance.searchAPIsForPublisher(org, "", 0,
-                    Integer.MAX_VALUE, userCtx, null, null);
+                    Integer.MAX_VALUE, userCtx);
 
             if (searchAPIs != null) {
                 List<PublisherAPIInfo> list = searchAPIs.getPublisherAPIInfoList();


### PR DESCRIPTION
## Purpose
To fix https://github.com/wso2/api-manager/issues/4334

## Goals
supporting https support in monetization with elk.
Added the related config with [1] 

## Approach
Added the SSLContext to the REST client

## User stories
user has to import the related certificate to the client-truststore if https is used.

## Samples
N/A

## Related PRs
[1] https://github.com/wso2/carbon-apimgt/pull/13473